### PR TITLE
Explicitly bind comp/*parent* in BodyContainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 ### Fixed
+- Fix namespaced classes not working as direct children in error boundary by explicitly binding comp/*parent* 
+  to the parent retrieved from the error-boundary macro
 
 ## [v0.0.71]
 ### Added

--- a/modules/rollbar/src/com/avisi_apps/gaps/rollbar.clj
+++ b/modules/rollbar/src/com/avisi_apps/gaps/rollbar.clj
@@ -9,10 +9,13 @@
     * :error-message, the message that will be sent along the error
     * :fallback-ui-fn, the UI components to be rendered when an error occurs
 
+  The `:error-message` can also be a function with the signature: `(fn [error props] message-to-sent)`,
+  see Rollbar's react documentation for more details on the props.
+
   The `:fallback-ui-fn` function takes function with the signature: `(fn [props] what-to-render)`,
   where the props is a bean with the key `:error`."
   [opts & body]
   `(error-boundary*
      (assoc ~opts
        :parent comp/*parent*
-       :render #(comp/fragment ~@body))))
+       :render #(comp/with-parent-context % (comp/fragment ~@body)))))

--- a/modules/rollbar/src/com/avisi_apps/gaps/rollbar.cljs
+++ b/modules/rollbar/src/com/avisi_apps/gaps/rollbar.cljs
@@ -46,8 +46,8 @@
 (defsc BodyContainer
   [_ {:keys [parent render]}]
   {:use-hooks? true}
-  (comp/with-parent-context parent
-    (render)))
+  (binding [comp/*parent* parent]
+    (render parent)))
 
 (def ui-body-container (comp/factory BodyContainer))
 


### PR DESCRIPTION
By `with-parent-context` doesn't actually set the parent passed in to the parent, but it uses the containing component. So every element got the BodyContainer as it's parent. By explicitly binding comp/*parent* we bypass that behaviour, but keeping the component offset for the ErrorBoundary.