### PR TITLE
centralised migration orchestration - directly publishing to leader project

### DIFF
--- a/modules/data-residency-migrations/src/com/avisi_apps/gaps/data_residency_migrations/core.cljs
+++ b/modules/data-residency-migrations/src/com/avisi_apps/gaps/data_residency_migrations/core.cljs
@@ -29,7 +29,13 @@
       {:status 500
        :body "Unexpected error"})))
 
-(def ^:private migrations-topic "dare-migrations")
+; for now migration leaders are hardcoded to be in the us region
+(defn ^:private project-id->migrations-topic [project-id]
+  (let [[app-name environment _] (->
+                                   project-id
+                                   (str/split #"-"))
+        leader-project (str/join "-" [app-name environment "us"])]
+    (str "projects/" leader-project "/topics/dare-migrations")))
 
 (defn ^:private handle-migration-event [{:keys [installation migration-data tenant-ref]}]
   (let [tenant (:clientKey installation)
@@ -37,13 +43,13 @@
     (condp contains? (:phase migration-data)
       #{"schedule"}
         (let [source-project (get-project-id)
-              [app-name stage _] (->
-                                   source-project
-                                   (str/split #"-"))
+              [app-name environment _] (->
+                                         source-project
+                                         (str/split #"-"))
               destination-region-label (str/lower-case (:location migration-data))
-              destination-project (str/join "-" [app-name stage destination-region-label])]
+              destination-project (str/join "-" [app-name environment destination-region-label])]
           (pubsub/publish-message!
-            migrations-topic
+            (project-id->migrations-topic source-project)
             {:attributes
                {:tenant tenant
                 :source_project source-project


### PR DESCRIPTION
This PR is part of the effort to make one region leader of the dare-migrations for all regions an app operates in (as opposed to each region orchestrating the migrations away from it).

I would have preferred to solve this on the infrastructure level. But it's surprisingly hard to forward a message from one topic to another. Not impossible, but the needed setup/resources are either unnecessarily elaborate or expensive.

So solving it in the application code isn't the most pretty but it works, so fine. 

We could make the migration leader configurable in the future, but really why?  