### PR TITLE
Dare migrations module: Accommodate for projects being able to host multiple dare-regions

### DIFF
--- a/modules/data-residency-migrations/src/com/avisi_apps/gaps/data_residency_migrations/core.cljs
+++ b/modules/data-residency-migrations/src/com/avisi_apps/gaps/data_residency_migrations/core.cljs
@@ -39,19 +39,20 @@
     (condp contains? phase
       #{"schedule"}
         (let [source-project (get-project-id)
-              [app-name stage _] (->
-                                   source-project
-                                   (str/split #"-"))
-              destination-region-label (str/lower-case location)
-              destination-project (str/join "-" [app-name stage destination-region-label])]
+              [app-name development-stage source-region] (->
+                                                           source-project
+                                                           (str/split #"-"))
+              destination-region (str/lower-case location)]
           (pubsub/publish-message!
             migrations-topic
             {:attributes
                {:tenant tenant
                 :base_url base-url
                 :phase phase
-                :source_project source-project
-                :destination_project destination-project
+                :app_name app-name
+                :development_stage development-stage
+                :source_region source-region
+                :destination_region destination-region
                 :start_time start-time
                 :end_time end-time}}))
       #{"start" "commit" "rollback"}


### PR DESCRIPTION
Moved away from determining and passing on the destination project as this can't be constructed anymore solely on knowledge of the current project and destination region (due to the possibility of projects hosting multiple regions). We'll leave this work to downstream processors. 