### PR TITLE
Fix negotiation handling with charsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 ### Fixed
+Fix content negoation to handle content-types better. #68
 
 ## [v0.0.129]
 ### Added

--- a/modules/reitit-express/src/com/avisi_apps/gaps/reitit_express/middleware/content_negotiation.cljs
+++ b/modules/reitit-express/src/com/avisi_apps/gaps/reitit_express/middleware/content_negotiation.cljs
@@ -10,11 +10,14 @@
 (defn extract-accept-header-ring "Extract accept header from ring request" [request] (get (:headers request) "accept"))
 
 (defn accept-header->media-type [accept-header supported-media-types]
-  (.mediaType ^js (negotiator/Negotiator #js {:headers #js {:accept accept-header}}) (clj->js supported-media-types)))
+  (let [media-type (.mediaType ^js (negotiator/Negotiator #js {:headers #js {:accept accept-header}}))]
+    (if (= media-type "*/*") (first supported-media-types) (get (set supported-media-types) media-type))))
 
 (tests
   "Basic application/json test"
     (accept-header->media-type "application/json" ["application/json" "application/transit+json"])
+  "Basic application/json test with utf-8 encoding"
+    (accept-header->media-type "application/json; charset=utf-8" ["application/json" "application/transit+json"])
   := "application/json"
   "Accept any */*" (accept-header->media-type "*/*" ["application/json" "application/transit+json"])
   := "application/json"


### PR DESCRIPTION
For some reason the negotiator library has way stricter matching when giving it accepted media types, this solves it by doing the matchin ourselves.

Fixes #68